### PR TITLE
feat: expose hocrtransform entrypoint with redaction capabilities

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ where = src
 [options.entry_points]
 console_scripts =
     ocrmypdf = ocrmypdf.__main__:run
+    hocrtransform = ocrmypdf.hocrtransform:run
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
# Changes

* Exposes the `hocrtransform` script through an entrypoint of similar name
* Adds a `redact` flag to the `hocrtransform` cmd. If this is set to true, any `ocrx_word` inside the hocr file, which contains the meta tag `redact_class`, will be redacted with a black overlaying box and with the text of `redact_class` overlayed as white text. 

Notice, that there is some duplication between the new `_redact_line` method and `_do_line`. It proved difficult to implement the redaction directly in the original `_do_line`, as this is run before the `.png` image is overlayed. Furthermore since things are on a line basis, it turned out to be easier to simply copy the necessary logic and modify where needed. I don't think it is worth it spending more time on refactoring this anyhow, in order to avoid duplication.

## To review
- [ ] Install this branch to a local environment
    ```bash
    python -m venv .venv
    source .venv/bin/activate
    pip install git+https://github.com/ante-dk/OCRmyPDF@feat/expose-hocrtransform-with-redaction-capabilities
    ```
- [ ] Try to run a document through `ocrmypdf`
    ```bash
    ocrmypdf --output-type pdf -l swe --force-ocr --tesseract-config hocr --keep-temporary-files <SOME-INPUT-PDF> out.pdf
    ```
    This will produce a folder in /tmp/. Take the hocr file of the first page `000001_ocr_tess.hocr` and the `.png` `000001_ocr.png`. Modify the hocr file by adding a meta tag to some of the `ocrx_word` fields. You will need to add the field `redact_class` with some string value you would like. Try now to produce a pdf for that page:
    ```bash
    hocrtransform -i <PATH-TO-PNG> --interword-spaces <PATH-TO-HOCR> --redact out.pdf
    ```
    Check out the newly redacted pdf and see that everything looks as you would expect. Notice that neighbouring `ocrx_word` boxes which have the same `redact_class` are merged.
- [ ] Check that the text inside the drawn boxes is the same as in `redact_class` and **not** what is actually inside the `ocrx_word` box.