### PR TITLE
Feat/fix spaces between overlapping entities

### DIFF
--- a/src/ocrmypdf/hocrtransform.py
+++ b/src/ocrmypdf/hocrtransform.py
@@ -573,7 +573,10 @@ class HocrTransform:
 
             if debug:
                 pdf.setStrokeColor(classColors.get(redact_label, "black"))
-                pdf.setFillColor(classColors.get(redact_label, "black"), 0)
+                if redact_origin == "model":
+                    pdf.setFillColor(classColors.get(redact_label, "black"), 0.10)
+                else:
+                    pdf.setFillColor(classColors.get(redact_label, "black"), 0)
                 pdf.rect(
                     box.x1,
                     self.height - line_box.y2,

--- a/src/ocrmypdf/hocrtransform.py
+++ b/src/ocrmypdf/hocrtransform.py
@@ -528,9 +528,9 @@ class HocrTransform:
             "M-NAME": "blue",
             "M-ADDRESS": "blue",
             "M-CPR": "blue",
-            "VH-NAME": "cyan",
-            "VH-CPR": "cyan",
-            "VH-ADDRESS": "cyan",
+            "VH-NAME": "purple",
+            "VH-CPR": "purple",
+            "VH-ADDRESS": "purple",
         }
         # Redacted boxes should be black
         pdf.setFillColor(black)


### PR DESCRIPTION
# Changes

* Fixes the issue of thin artifact lines between merged entities in redaction, by drawing a single box
* Adds an overlay color to the entities in debug mode, with fill/non-fill for model/fuzzy origins
* Changes the cyan color to purple rain as the cyan was really an eye-strainer