### PR TITLE
fix: include valid hocr text objects in hocrtransform

### DIFF
--- a/src/ocrmypdf/hocrtransform.py
+++ b/src/ocrmypdf/hocrtransform.py
@@ -95,6 +95,13 @@ HOCR_OK_LANGS = frozenset(
         'wel',  # Welsh
     ]
 )
+HOCR_LINE_ALIKE = {
+    'ocr_header',
+    'ocr_footer',
+    'ocr_line',
+    'ocr_textfloat',
+    'ocr_caption',
+}
 
 
 Element = ElementTree.Element
@@ -307,7 +314,7 @@ class HocrTransform:
             element
             for element in self.hocr.iterfind(self._child_xpath('span'))
             if 'class' in element.attrib
-            and element.attrib['class'] in {'ocr_header', 'ocr_line', 'ocr_textfloat'}
+            and element.attrib['class'] in HOCR_LINE_ALIKE
         ):
             found_lines = True
             line_font_sizes.append(
@@ -354,7 +361,7 @@ class HocrTransform:
                     element
                     for element in self.hocr.iterfind(self._child_xpath('span'))
                     if 'class' in element.attrib
-                    and element.attrib['class'] in {'ocr_header', 'ocr_line', 'ocr_textfloat'}
+                    and element.attrib['class'] in HOCR_LINE_ALIKE
                 ):
                     self._redact_line(pdf, line, "ocrx_word", fontname, median_font_size, interword_spaces, debug)
             else:


### PR DESCRIPTION
# Changes

* Adds `ocr_footer` and `ocr_caption` to the elements which we consider line-alike. Tesseract can sometimes identify a table field as a `ocr_caption`, so this should remedy that. Futhermore since we already include `ocr_header` I thought that we might as well also include the footer.